### PR TITLE
feat: Add repository archiving feature

### DIFF
--- a/ARCHIVING_FEATURE.md
+++ b/ARCHIVING_FEATURE.md
@@ -1,0 +1,137 @@
+# Repository Archiving Feature
+
+## Overview
+
+This feature allows users to archive repositories, hiding them from the "Your Repositories" sidebar while keeping them accessible in Settings. Archived repositories are treated as read-only in the UI.
+
+## Implementation Details
+
+### Backend Changes
+
+#### 1. Repository Layer (`roadmap_repository.py`)
+
+Added three new methods to `UserSyncedRepoStore`:
+
+- **`archive(user_id, full_name)`**: Sets `is_archived=True` for a user's repository
+- **`unarchive(user_id, full_name)`**: Sets `is_archived=False` for a user's repository
+- **`list_archived(user_id)`**: Returns all archived repositories for a user
+
+All methods use the existing `_with_table_guard` pattern for safe database operations.
+
+#### 2. Service Layer (`roadmap_service.py`)
+
+Added three new methods to `RoadmapService`:
+
+- **`archive_repo(owner, repo, user_id)`**: Archives a repository, validates it exists, and returns updated state
+- **`unarchive_repo(owner, repo, user_id)`**: Unarchives a repository, validates it's archived, and returns updated state
+- **`list_archived_repos(user_id)`**: Returns list of archived repositories for a user
+
+All methods include proper error handling with HTTP exceptions for missing repositories.
+
+#### 3. API Endpoints (`roadmap.py`)
+
+Added three new authenticated endpoints:
+
+- **`POST /api/v1/roadmap/archive/{owner}/{repo}`**: Archive a repository
+- **`POST /api/v1/roadmap/unarchive/{owner}/{repo}`**: Unarchive a repository
+- **`GET /api/v1/roadmap/archived`**: List archived repositories for current user
+
+All endpoints require `require_clerk_auth` authentication.
+
+### Frontend Changes
+
+#### 1. Service Layer (`repos.ts`)
+
+Added three new methods to `repoService`:
+
+- **`archiveRepo(owner, repo, authToken)`**: Calls archive endpoint
+- **`unarchiveRepo(owner, repo, authToken)`**: Calls unarchive endpoint
+- **`listArchivedRepos(authToken)`**: Calls list archived endpoint
+
+All methods follow the existing API client pattern with proper error handling.
+
+#### 2. Context Provider (`roadmap-catalog-provider.tsx`)
+
+Extended `RoadmapCatalogProvider` with:
+
+- **`archivedRepos` state**: Stores list of archived repositories
+- **`refreshArchivedRepos()` function**: Fetches archived repos from API
+- **`archive(fullName)` function**: Archives a repo and updates local state
+- **`unarchive(fullName)` function**: Unarchives a repo and updates local state
+
+The provider automatically loads archived repos when the user is signed in.
+
+#### 3. Settings UI (`account-settings-dialog.tsx`)
+
+Added new "Archived Repositories" page to the settings dialog:
+
+- Displays list of archived repositories with descriptions
+- Shows empty state when no archived repos exist
+- Provides "Unarchive" button for each archived repo
+- Includes loading states during unarchive operations
+- Shows read-only indicator for archived repos
+
+#### 4. Sidebar (`sidebar.tsx`)
+
+The sidebar already filters out archived repos using:
+
+```typescript
+const userReposToRender = useMemo(
+  () => yourRepos.filter((repo) => !repo.is_archived),
+  [yourRepos]
+);
+```
+
+No changes were needed here.
+
+## Database Schema
+
+The `is_archived` field already exists in the `UserSyncedRepo` model:
+
+```python
+is_archived: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+```
+
+This was added in a previous migration (`20241116_upgrade_roadmaps_and_user_repo_state.py`).
+
+## User Flow
+
+1. **Archiving a Repository**:
+   - User can archive a repo (implementation depends on where archive action is triggered)
+   - Repo disappears from "Your Repositories" sidebar
+   - Repo appears in Settings > Archived Repositories
+
+2. **Viewing Archived Repositories**:
+   - User opens Settings dialog
+   - Navigates to "Archived Repositories" tab
+   - Sees list of all archived repos with descriptions
+
+3. **Unarchiving a Repository**:
+   - User clicks "Unarchive" button in Settings
+   - Repo is unarchived via API
+   - Repo reappears in "Your Repositories" sidebar
+   - Repo is removed from archived list
+
+## Security Considerations
+
+- All archive/unarchive operations require authentication via Clerk
+- Users can only archive/unarchive their own repositories
+- Backend validates repository ownership before allowing operations
+
+## Future Enhancements
+
+- Add archive action to repository cards/context menus
+- Add bulk archive/unarchive operations
+- Add archive date tracking
+- Add search/filter for archived repositories
+
+## Testing Notes
+
+- Test archiving a synced repository
+- Test unarchiving an archived repository
+- Test listing archived repositories
+- Test that archived repos don't appear in sidebar
+- Test that archived repos appear in settings
+- Test error handling for non-existent repositories
+- Test authentication requirements
+

--- a/commitly-backend/app/api/roadmap.py
+++ b/commitly-backend/app/api/roadmap.py
@@ -98,3 +98,31 @@ async def desync_repository(
 ) -> Response:
     await service.desync_repo(owner, repo, current_user["sub"])
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/archive/{owner}/{repo}", response_model=UserRepoStateResponse)
+async def archive_repository(
+    owner: str,
+    repo: str,
+    current_user: ClerkClaims = Depends(require_clerk_auth),
+    service: RoadmapService = Depends(get_roadmap_service),
+) -> UserRepoStateResponse:
+    return await service.archive_repo(owner, repo, current_user["sub"])
+
+
+@router.post("/unarchive/{owner}/{repo}", response_model=UserRepoStateResponse)
+async def unarchive_repository(
+    owner: str,
+    repo: str,
+    current_user: ClerkClaims = Depends(require_clerk_auth),
+    service: RoadmapService = Depends(get_roadmap_service),
+) -> UserRepoStateResponse:
+    return await service.unarchive_repo(owner, repo, current_user["sub"])
+
+
+@router.get("/archived", response_model=list[UserRepoStateResponse])
+async def list_archived_repositories(
+    current_user: ClerkClaims = Depends(require_clerk_auth),
+    service: RoadmapService = Depends(get_roadmap_service),
+) -> list[UserRepoStateResponse]:
+    return await service.list_archived_repos(current_user["sub"])

--- a/commitly-backend/app/services/roadmap_repository.py
+++ b/commitly-backend/app/services/roadmap_repository.py
@@ -397,3 +397,82 @@ class UserSyncedRepoStore:
             return responses
 
         return self._with_table_guard(action)
+
+    def archive(self, user_id: str, full_name: str) -> None:
+        """Archive a repository for a user."""
+
+        def action() -> None:
+            try:
+                record = (
+                    self._session.query(UserSyncedRepo)
+                    .filter_by(user_id=user_id, repo_full_name=full_name)
+                    .one_or_none()
+                )
+                if record:
+                    record.is_archived = True
+                    record.updated_at = datetime.now(timezone.utc)
+                    self._session.commit()
+            except SQLAlchemyError:
+                self._session.rollback()
+                raise
+
+        self._with_table_guard(action)
+
+    def unarchive(self, user_id: str, full_name: str) -> None:
+        """Unarchive a repository for a user."""
+
+        def action() -> None:
+            try:
+                record = (
+                    self._session.query(UserSyncedRepo)
+                    .filter_by(user_id=user_id, repo_full_name=full_name)
+                    .one_or_none()
+                )
+                if record:
+                    record.is_archived = False
+                    record.updated_at = datetime.now(timezone.utc)
+                    self._session.commit()
+            except SQLAlchemyError:
+                self._session.rollback()
+                raise
+
+        self._with_table_guard(action)
+
+    def list_archived(self, user_id: str | None) -> list[UserRepoStateResponse]:
+        """List archived repositories for a user."""
+        if not user_id:
+            return []
+
+        def action() -> list[UserRepoStateResponse]:
+            results = (
+                self._session.query(UserSyncedRepo, GeneratedRoadmap)
+                .outerjoin(
+                    GeneratedRoadmap,
+                    GeneratedRoadmap.repo_full_name == UserSyncedRepo.repo_full_name,
+                )
+                .filter(
+                    UserSyncedRepo.user_id == user_id,
+                    UserSyncedRepo.is_archived == True,  # noqa: E712
+                )
+                .order_by(UserSyncedRepo.pinned_at.desc())
+                .all()
+            )
+
+            responses: list[UserRepoStateResponse] = []
+            for user_record, roadmap_record in results:
+                summary = None
+                if roadmap_record and roadmap_record.repo_summary:
+                    summary = RoadmapRepoSummary(**roadmap_record.repo_summary)
+                responses.append(
+                    UserRepoStateResponse(
+                        repo_full_name=user_record.repo_full_name,
+                        status=user_record.status,
+                        is_archived=user_record.is_archived,
+                        progress_percent=user_record.progress_percent,
+                        pinned_at=user_record.pinned_at,
+                        repo=summary,
+                    )
+                )
+            return responses
+
+        return self._with_table_guard(action)

--- a/commitly-backend/app/services/roadmap_service.py
+++ b/commitly-backend/app/services/roadmap_service.py
@@ -219,6 +219,64 @@ class RoadmapService:
     async def unpin_repo(self, user_id: str, repo_full_name: str) -> None:
         self._pin_store.unpin(user_id, repo_full_name)
 
+    async def archive_repo(
+        self, owner: str, repo: str, user_id: str
+    ) -> UserRepoStateResponse:
+        """Archive a repository for a user."""
+        full_name = f"{owner}/{repo}"
+        states = self._pin_store.list_states(user_id)
+        existing_state = next(
+            (state for state in states if state.repo_full_name == full_name), None
+        )
+        if not existing_state:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Repository is not synced for this user.",
+            )
+        self._pin_store.archive(user_id, full_name)
+        updated_states = self._pin_store.list_states(user_id)
+        updated_state = next(
+            (state for state in updated_states if state.repo_full_name == full_name),
+            None,
+        )
+        if not updated_state:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to archive repository.",
+            )
+        return updated_state
+
+    async def unarchive_repo(
+        self, owner: str, repo: str, user_id: str
+    ) -> UserRepoStateResponse:
+        """Unarchive a repository for a user."""
+        full_name = f"{owner}/{repo}"
+        archived = self._pin_store.list_archived(user_id)
+        existing_archived = next(
+            (state for state in archived if state.repo_full_name == full_name), None
+        )
+        if not existing_archived:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Repository is not archived for this user.",
+            )
+        self._pin_store.unarchive(user_id, full_name)
+        updated_states = self._pin_store.list_states(user_id)
+        updated_state = next(
+            (state for state in updated_states if state.repo_full_name == full_name),
+            None,
+        )
+        if not updated_state:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to unarchive repository.",
+            )
+        return updated_state
+
+    async def list_archived_repos(self, user_id: str) -> list[UserRepoStateResponse]:
+        """List archived repositories for a user."""
+        return self._pin_store.list_archived(user_id)
+
     def _parse_identity(self, repo_url: str) -> RepositoryIdentity:
         try:
             return parse_github_url(repo_url)

--- a/commitly-backend/tests/test_roadmap.py
+++ b/commitly-backend/tests/test_roadmap.py
@@ -221,3 +221,402 @@ def test_sync_repo_idempotent(db_session):
     assert record.repo.full_name == "acme/widgets"
     # sync_count should only increment on first sync for this user
     assert record.repo.sync_count == 1
+
+
+def test_desync_endpoint(client: TestClient, auth_headers, db_session):
+    """Test desync endpoint removes repository from user's synced repos."""
+    from app.services.github_tokens import GitHubTokenStore
+    from app.services.rag import CommitChunkStore
+    from app.services.roadmap_repository import RoadmapResultStore, UserSyncedRepoStore
+    from app.services.roadmap_service import RoadmapService
+
+    result_store = RoadmapResultStore(db_session)
+    pin_store = UserSyncedRepoStore(db_session, result_store)
+    service = RoadmapService(
+        chunk_store=CommitChunkStore(db_session),
+        result_store=result_store,
+        pin_store=pin_store,
+        generator=None,
+        token_store=GitHubTokenStore(db_session),
+    )
+
+    # Create a roadmap and sync it
+    roadmap = RoadmapResponse(
+        repo=RoadmapRepoSummary(
+            full_name="acme/widgets",
+            description="Test repo",
+            language="Python",
+            stars=10,
+            default_branch="main",
+            html_url=None,
+            owner_avatar_url=None,
+        ),
+        timeline=[],
+        cached=True,
+        generated_at=datetime.now(timezone.utc),
+    )
+    result_store.upsert(roadmap)
+    asyncio.run(service.sync_repo("acme", "widgets", "user_123"))
+
+    # Verify it's synced
+    states = pin_store.list_states("user_123")
+    assert len(states) == 1
+    assert states[0].repo_full_name == "acme/widgets"
+
+    # Desync it
+    response = client.delete("/api/v1/roadmap/sync/acme/widgets", headers=auth_headers)
+    assert response.status_code == 204
+
+    # Verify it's removed
+    states_after = pin_store.list_states("user_123")
+    assert len(states_after) == 0
+
+
+def test_desync_endpoint_requires_auth(client: TestClient, db_session):
+    """Test desync endpoint requires authentication."""
+    response = client.delete("/api/v1/roadmap/sync/acme/widgets")
+    assert response.status_code == 401
+
+
+def test_desync_nonexistent_repo(client: TestClient, auth_headers, db_session):
+    """Test desync endpoint handles nonexistent repo gracefully."""
+    response = client.delete(
+        "/api/v1/roadmap/sync/nonexistent/repo", headers=auth_headers
+    )
+    # Should return 204 even if repo doesn't exist (idempotent operation)
+    assert response.status_code == 204
+
+
+def test_archive_endpoint(client: TestClient, auth_headers, db_session):
+    """Test archive endpoint archives a repository."""
+    from app.services.github_tokens import GitHubTokenStore
+    from app.services.rag import CommitChunkStore
+    from app.services.roadmap_repository import RoadmapResultStore, UserSyncedRepoStore
+    from app.services.roadmap_service import RoadmapService
+
+    result_store = RoadmapResultStore(db_session)
+    pin_store = UserSyncedRepoStore(db_session, result_store)
+    service = RoadmapService(
+        chunk_store=CommitChunkStore(db_session),
+        result_store=result_store,
+        pin_store=pin_store,
+        generator=None,
+        token_store=GitHubTokenStore(db_session),
+    )
+
+    # Create a roadmap and sync it
+    roadmap = RoadmapResponse(
+        repo=RoadmapRepoSummary(
+            full_name="acme/widgets",
+            description="Test repo",
+            language="Python",
+            stars=10,
+            default_branch="main",
+            html_url=None,
+            owner_avatar_url=None,
+        ),
+        timeline=[],
+        cached=True,
+        generated_at=datetime.now(timezone.utc),
+    )
+    result_store.upsert(roadmap)
+    asyncio.run(service.sync_repo("acme", "widgets", "user_123"))
+
+    # Verify it's not archived
+    states = pin_store.list_states("user_123")
+    assert len(states) == 1
+    assert states[0].is_archived is False
+
+    # Archive it
+    response = client.post("/api/v1/roadmap/archive/acme/widgets", headers=auth_headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["is_archived"] is True
+    assert data["repo_full_name"] == "acme/widgets"
+
+    # Verify it's archived in database
+    states_after = pin_store.list_states("user_123")
+    assert len(states_after) == 1
+    assert states_after[0].is_archived is True
+
+
+def test_archive_endpoint_requires_auth(client: TestClient, db_session):
+    """Test archive endpoint requires authentication."""
+    response = client.post("/api/v1/roadmap/archive/acme/widgets")
+    assert response.status_code == 401
+
+
+def test_archive_nonexistent_repo(client: TestClient, auth_headers, db_session):
+    """Test archive endpoint returns 404 for nonexistent repo."""
+    response = client.post(
+        "/api/v1/roadmap/archive/nonexistent/repo", headers=auth_headers
+    )
+    assert response.status_code == 404
+    assert "not synced" in response.json()["detail"].lower()
+
+
+def test_unarchive_endpoint(client: TestClient, auth_headers, db_session):
+    """Test unarchive endpoint unarchives a repository."""
+    from app.services.github_tokens import GitHubTokenStore
+    from app.services.rag import CommitChunkStore
+    from app.services.roadmap_repository import RoadmapResultStore, UserSyncedRepoStore
+    from app.services.roadmap_service import RoadmapService
+
+    result_store = RoadmapResultStore(db_session)
+    pin_store = UserSyncedRepoStore(db_session, result_store)
+    service = RoadmapService(
+        chunk_store=CommitChunkStore(db_session),
+        result_store=result_store,
+        pin_store=pin_store,
+        generator=None,
+        token_store=GitHubTokenStore(db_session),
+    )
+
+    # Create a roadmap and sync it
+    roadmap = RoadmapResponse(
+        repo=RoadmapRepoSummary(
+            full_name="acme/widgets",
+            description="Test repo",
+            language="Python",
+            stars=10,
+            default_branch="main",
+            html_url=None,
+            owner_avatar_url=None,
+        ),
+        timeline=[],
+        cached=True,
+        generated_at=datetime.now(timezone.utc),
+    )
+    result_store.upsert(roadmap)
+    asyncio.run(service.sync_repo("acme", "widgets", "user_123"))
+
+    # Archive it first
+    asyncio.run(service.archive_repo("acme", "widgets", "user_123"))
+
+    # Verify it's archived
+    archived = pin_store.list_archived("user_123")
+    assert len(archived) == 1
+    assert archived[0].is_archived is True
+
+    # Unarchive it
+    response = client.post(
+        "/api/v1/roadmap/unarchive/acme/widgets", headers=auth_headers
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["is_archived"] is False
+    assert data["repo_full_name"] == "acme/widgets"
+
+    # Verify it's unarchived in database
+    archived_after = pin_store.list_archived("user_123")
+    assert len(archived_after) == 0
+
+    states = pin_store.list_states("user_123")
+    assert len(states) == 1
+    assert states[0].is_archived is False
+
+
+def test_unarchive_endpoint_requires_auth(client: TestClient, db_session):
+    """Test unarchive endpoint requires authentication."""
+    response = client.post("/api/v1/roadmap/unarchive/acme/widgets")
+    assert response.status_code == 401
+
+
+def test_unarchive_nonexistent_repo(client: TestClient, auth_headers, db_session):
+    """Test unarchive endpoint returns 404 for nonexistent repo."""
+    response = client.post(
+        "/api/v1/roadmap/unarchive/nonexistent/repo", headers=auth_headers
+    )
+    assert response.status_code == 404
+    assert "not archived" in response.json()["detail"].lower()
+
+
+def test_unarchive_not_archived_repo(client: TestClient, auth_headers, db_session):
+    """Test unarchive endpoint returns 404 for repo that's not archived."""
+    from app.services.github_tokens import GitHubTokenStore
+    from app.services.rag import CommitChunkStore
+    from app.services.roadmap_repository import RoadmapResultStore, UserSyncedRepoStore
+    from app.services.roadmap_service import RoadmapService
+
+    result_store = RoadmapResultStore(db_session)
+    pin_store = UserSyncedRepoStore(db_session, result_store)
+    service = RoadmapService(
+        chunk_store=CommitChunkStore(db_session),
+        result_store=result_store,
+        pin_store=pin_store,
+        generator=None,
+        token_store=GitHubTokenStore(db_session),
+    )
+
+    # Create a roadmap and sync it (but don't archive)
+    roadmap = RoadmapResponse(
+        repo=RoadmapRepoSummary(
+            full_name="acme/widgets",
+            description="Test repo",
+            language="Python",
+            stars=10,
+            default_branch="main",
+            html_url=None,
+            owner_avatar_url=None,
+        ),
+        timeline=[],
+        cached=True,
+        generated_at=datetime.now(timezone.utc),
+    )
+    result_store.upsert(roadmap)
+    asyncio.run(service.sync_repo("acme", "widgets", "user_123"))
+
+    # Try to unarchive (should fail)
+    response = client.post(
+        "/api/v1/roadmap/unarchive/acme/widgets", headers=auth_headers
+    )
+    assert response.status_code == 404
+    assert "not archived" in response.json()["detail"].lower()
+
+
+def test_list_archived_endpoint(client: TestClient, auth_headers, db_session):
+    """Test list archived endpoint returns archived repositories."""
+    from app.services.github_tokens import GitHubTokenStore
+    from app.services.rag import CommitChunkStore
+    from app.services.roadmap_repository import RoadmapResultStore, UserSyncedRepoStore
+    from app.services.roadmap_service import RoadmapService
+
+    result_store = RoadmapResultStore(db_session)
+    pin_store = UserSyncedRepoStore(db_session, result_store)
+    service = RoadmapService(
+        chunk_store=CommitChunkStore(db_session),
+        result_store=result_store,
+        pin_store=pin_store,
+        generator=None,
+        token_store=GitHubTokenStore(db_session),
+    )
+
+    # Create two roadmaps
+    roadmap1 = RoadmapResponse(
+        repo=RoadmapRepoSummary(
+            full_name="acme/widgets",
+            description="Test repo 1",
+            language="Python",
+            stars=10,
+            default_branch="main",
+            html_url=None,
+            owner_avatar_url=None,
+        ),
+        timeline=[],
+        cached=True,
+        generated_at=datetime.now(timezone.utc),
+    )
+    roadmap2 = RoadmapResponse(
+        repo=RoadmapRepoSummary(
+            full_name="acme/tools",
+            description="Test repo 2",
+            language="TypeScript",
+            stars=20,
+            default_branch="main",
+            html_url=None,
+            owner_avatar_url=None,
+        ),
+        timeline=[],
+        cached=True,
+        generated_at=datetime.now(timezone.utc),
+    )
+    result_store.upsert(roadmap1)
+    result_store.upsert(roadmap2)
+
+    # Sync both
+    asyncio.run(service.sync_repo("acme", "widgets", "user_123"))
+    asyncio.run(service.sync_repo("acme", "tools", "user_123"))
+
+    # Archive one
+    asyncio.run(service.archive_repo("acme", "widgets", "user_123"))
+
+    # List archived
+    response = client.get("/api/v1/roadmap/archived", headers=auth_headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["repo_full_name"] == "acme/widgets"
+    assert data[0]["is_archived"] is True
+
+    # Archive the other one
+    asyncio.run(service.archive_repo("acme", "tools", "user_123"))
+
+    # List archived again
+    response = client.get("/api/v1/roadmap/archived", headers=auth_headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    repo_names = {repo["repo_full_name"] for repo in data}
+    assert repo_names == {"acme/widgets", "acme/tools"}
+    assert all(repo["is_archived"] is True for repo in data)
+
+
+def test_list_archived_endpoint_requires_auth(client: TestClient, db_session):
+    """Test list archived endpoint requires authentication."""
+    response = client.get("/api/v1/roadmap/archived")
+    assert response.status_code == 401
+
+
+def test_list_archived_empty(client: TestClient, auth_headers, db_session):
+    """Test list archived endpoint returns empty list when no archived repos."""
+    response = client.get("/api/v1/roadmap/archived", headers=auth_headers)
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_archive_unarchive_cycle(client: TestClient, auth_headers, db_session):
+    """Test that archive/unarchive cycle works correctly."""
+    from app.services.github_tokens import GitHubTokenStore
+    from app.services.rag import CommitChunkStore
+    from app.services.roadmap_repository import RoadmapResultStore, UserSyncedRepoStore
+    from app.services.roadmap_service import RoadmapService
+
+    result_store = RoadmapResultStore(db_session)
+    pin_store = UserSyncedRepoStore(db_session, result_store)
+    service = RoadmapService(
+        chunk_store=CommitChunkStore(db_session),
+        result_store=result_store,
+        pin_store=pin_store,
+        generator=None,
+        token_store=GitHubTokenStore(db_session),
+    )
+
+    # Create and sync a roadmap
+    roadmap = RoadmapResponse(
+        repo=RoadmapRepoSummary(
+            full_name="acme/widgets",
+            description="Test repo",
+            language="Python",
+            stars=10,
+            default_branch="main",
+            html_url=None,
+            owner_avatar_url=None,
+        ),
+        timeline=[],
+        cached=True,
+        generated_at=datetime.now(timezone.utc),
+    )
+    result_store.upsert(roadmap)
+    asyncio.run(service.sync_repo("acme", "widgets", "user_123"))
+
+    # Archive it
+    response = client.post("/api/v1/roadmap/archive/acme/widgets", headers=auth_headers)
+    assert response.status_code == 200
+    assert response.json()["is_archived"] is True
+
+    # Unarchive it
+    response = client.post(
+        "/api/v1/roadmap/unarchive/acme/widgets", headers=auth_headers
+    )
+    assert response.status_code == 200
+    assert response.json()["is_archived"] is False
+
+    # Archive it again
+    response = client.post("/api/v1/roadmap/archive/acme/widgets", headers=auth_headers)
+    assert response.status_code == 200
+    assert response.json()["is_archived"] is True
+
+    # Verify final state
+    states = pin_store.list_states("user_123")
+    assert len(states) == 1
+    assert states[0].is_archived is True

--- a/commitly-frontend/components/layout/sidebar/account-settings-dialog.tsx
+++ b/commitly-frontend/components/layout/sidebar/account-settings-dialog.tsx
@@ -2,13 +2,15 @@
 
 import { UserProfile, useAuth } from "@clerk/nextjs";
 import { dark } from "@clerk/themes";
-import { Bell, GitBranch, SlidersHorizontal } from "lucide-react";
+import { Archive, Bell, GitBranch, SlidersHorizontal } from "lucide-react";
 import { useEffect, useState } from "react";
+import { useRoadmapCatalog } from "@/components/providers/roadmap-catalog-provider";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { githubService } from "@/lib/services/github";
+import { repoService } from "@/lib/services/repos";
 
 type AccountSettingsDialogProps = {
   open: boolean;
@@ -54,6 +56,13 @@ export default function AccountSettingsDialog({
             url="connections"
           >
             <GithubConnectionPreferences />
+          </UserProfile.Page>
+          <UserProfile.Page
+            label="Archived Repositories"
+            labelIcon={<Archive className="h-3.5 w-3.5" />}
+            url="archived"
+          >
+            <ArchivedRepositoriesPreferences />
           </UserProfile.Page>
         </UserProfile>
       </DialogContent>
@@ -278,6 +287,84 @@ function GithubConnectionPreferences() {
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+function ArchivedRepositoriesPreferences() {
+  const { archivedRepos, unarchive, refreshArchivedRepos } =
+    useRoadmapCatalog();
+  const [loading, setLoading] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    refreshArchivedRepos().catch(() => {
+      // Error handling is done in the function
+    });
+  }, [refreshArchivedRepos]);
+
+  const handleUnarchive = async (fullName: string) => {
+    setLoading((prev) => ({ ...prev, [fullName]: true }));
+    try {
+      const success = await unarchive(fullName);
+      if (success) {
+        await refreshArchivedRepos();
+      }
+    } finally {
+      setLoading((prev) => ({ ...prev, [fullName]: false }));
+    }
+  };
+
+  return (
+    <div className="space-y-4 py-6 text-foreground text-sm">
+      {archivedRepos.length === 0 ? (
+        <div className="rounded-3xl border border-border/60 bg-background/60 p-6 text-center">
+          <Archive className="mx-auto mb-3 h-8 w-8 text-muted-foreground" />
+          <p className="font-medium text-base text-white">
+            No archived repositories
+          </p>
+          <p className="mt-1 text-white/60 text-xs">
+            Repositories you archive will appear here. You can unarchive them
+            anytime.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {archivedRepos.map((repo) => {
+            const isLoading = loading[repo.repo_full_name] ?? false;
+            return (
+              <div
+                className="rounded-3xl border border-border/60 bg-background/60 p-4"
+                key={repo.repo_full_name}
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <p className="truncate font-medium text-base text-white">
+                      {repo.repo_full_name}
+                    </p>
+                    {repo.repo?.description && (
+                      <p className="line-clamp-2 text-white/60 text-xs">
+                        {repo.repo.description}
+                      </p>
+                    )}
+                    <p className="text-white/40 text-xs">
+                      Archived repositories are read-only
+                    </p>
+                  </div>
+                  <Button
+                    disabled={isLoading}
+                    onClick={() => handleUnarchive(repo.repo_full_name)}
+                    size="sm"
+                    type="button"
+                    variant="outline"
+                  >
+                    {isLoading ? "Unarchiving..." : "Unarchive"}
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/commitly-frontend/components/providers/roadmap-catalog-provider.tsx
+++ b/commitly-frontend/components/providers/roadmap-catalog-provider.tsx
@@ -25,14 +25,18 @@ type CatalogContextValue = {
   synced: SyncedRepoRecord[];
   pending: PendingRepoRecord[];
   yourRepos: UserRepoState[];
+  archivedRepos: UserRepoState[];
   loading: boolean;
   error: string | null;
   refresh: () => Promise<void>;
   refreshUserRepos: () => Promise<void>;
+  refreshArchivedRepos: () => Promise<void>;
   upsertRoadmap: (roadmap: RoadmapResponseBody) => void;
   markPending: (identity: RepoIdentity) => void;
   getBySlug: (slug: string) => SyncedRepoRecord | PendingRepoRecord | undefined;
   desync: (fullName: string) => Promise<boolean>;
+  archive: (fullName: string) => Promise<boolean>;
+  unarchive: (fullName: string) => Promise<boolean>;
 };
 
 const RoadmapCatalogContext = createContext<CatalogContextValue | undefined>(
@@ -54,6 +58,7 @@ export function RoadmapCatalogProvider({ children }: { children: ReactNode }) {
   const [synced, setSynced] = useState<SyncedRepoRecord[]>([]);
   const [pending, setPending] = useState<PendingRepoRecord[]>([]);
   const [yourRepos, setYourRepos] = useState<UserRepoState[]>([]);
+  const [archivedRepos, setArchivedRepos] = useState<UserRepoState[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -113,6 +118,18 @@ export function RoadmapCatalogProvider({ children }: { children: ReactNode }) {
     }
   }, [backendConfigured, getToken, isSignedIn]);
 
+  const refreshArchivedRepos = useCallback(async () => {
+    if (!(backendConfigured && isSignedIn)) {
+      setArchivedRepos([]);
+      return;
+    }
+    const token = await getToken?.();
+    const response = await repoService.listArchivedRepos(token ?? undefined);
+    if (response.ok && response.data) {
+      setArchivedRepos(response.data);
+    }
+  }, [backendConfigured, getToken, isSignedIn]);
+
   const desync = useCallback(
     async (fullName: string) => {
       if (!(backendConfigured && isSignedIn)) {
@@ -139,11 +156,97 @@ export function RoadmapCatalogProvider({ children }: { children: ReactNode }) {
     [backendConfigured, getToken, isSignedIn]
   );
 
+  const archive = useCallback(
+    async (fullName: string) => {
+      if (!(backendConfigured && isSignedIn)) {
+        return false;
+      }
+      const identity = repoService.buildIdentityFromFullName(fullName);
+      const token = await getToken?.();
+      const response = await repoService.archiveRepo(
+        identity.owner,
+        identity.repoName,
+        token ?? undefined
+      );
+      if (response.ok && response.data) {
+        setYourRepos((prev) =>
+          prev.map((item) =>
+            item.repo_full_name === fullName
+              ? { ...item, is_archived: true }
+              : item
+          )
+        );
+        if (response.data) {
+          const updatedRepo = response.data;
+          setArchivedRepos((prev) => {
+            const exists = prev.some(
+              (item) => item.repo_full_name === fullName
+            );
+            if (exists) {
+              return prev.map((item) =>
+                item.repo_full_name === fullName ? updatedRepo : item
+              );
+            }
+            return [updatedRepo, ...prev];
+          });
+        }
+        return true;
+      }
+      return false;
+    },
+    [backendConfigured, getToken, isSignedIn]
+  );
+
+  const unarchive = useCallback(
+    async (fullName: string) => {
+      if (!(backendConfigured && isSignedIn)) {
+        return false;
+      }
+      const identity = repoService.buildIdentityFromFullName(fullName);
+      const token = await getToken?.();
+      const response = await repoService.unarchiveRepo(
+        identity.owner,
+        identity.repoName,
+        token ?? undefined
+      );
+      if (response.ok && response.data) {
+        setArchivedRepos((prev) =>
+          prev.filter((item) => item.repo_full_name !== fullName)
+        );
+        if (response.data) {
+          const updatedRepo = response.data;
+          setYourRepos((prev) => {
+            const exists = prev.some(
+              (item) => item.repo_full_name === fullName
+            );
+            if (exists) {
+              return prev.map((item) =>
+                item.repo_full_name === fullName ? updatedRepo : item
+              );
+            }
+            return [updatedRepo, ...prev];
+          });
+        }
+        return true;
+      }
+      return false;
+    },
+    [backendConfigured, getToken, isSignedIn]
+  );
+
   useEffect(() => {
-    if (!(backendConfigured && isSignedIn)) return;
+    if (!(backendConfigured && isSignedIn)) {
+      return;
+    }
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    void refreshUserRepos();
-  }, [backendConfigured, isSignedIn, refreshUserRepos]);
+    refreshUserRepos().catch(() => {
+      // Error handling is done in the function
+    });
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    refreshArchivedRepos().catch(() => {
+      // Error handling is done in the function
+    });
+  }, [backendConfigured, isSignedIn, refreshUserRepos, refreshArchivedRepos]);
 
   const upsertRoadmap = useCallback(
     (roadmap: RoadmapResponseBody) => {
@@ -213,27 +316,35 @@ export function RoadmapCatalogProvider({ children }: { children: ReactNode }) {
       synced,
       pending,
       yourRepos,
+      archivedRepos,
       loading,
       error,
       refresh,
       refreshUserRepos,
+      refreshArchivedRepos,
       upsertRoadmap,
       markPending,
       getBySlug,
       desync,
+      archive,
+      unarchive,
     }),
     [
       synced,
       pending,
       yourRepos,
+      archivedRepos,
       loading,
       error,
       refresh,
       refreshUserRepos,
+      refreshArchivedRepos,
       upsertRoadmap,
       markPending,
       getBySlug,
       desync,
+      archive,
+      unarchive,
     ]
   );
 

--- a/commitly-frontend/lib/services/repos.ts
+++ b/commitly-frontend/lib/services/repos.ts
@@ -16,6 +16,11 @@ const API_ROUTES = {
   userRepos: "/api/v1/roadmap/user-repos",
   sync: (owner: string, repo: string) =>
     `/api/v1/roadmap/sync/${owner}/${repo}`,
+  archive: (owner: string, repo: string) =>
+    `/api/v1/roadmap/archive/${owner}/${repo}`,
+  unarchive: (owner: string, repo: string) =>
+    `/api/v1/roadmap/unarchive/${owner}/${repo}`,
+  archived: "/api/v1/roadmap/archived",
 };
 
 export type RepoIdentity = {
@@ -253,6 +258,49 @@ export const repoService = {
     return apiClient<null>(env.apiBaseUrl, {
       path: API_ROUTES.sync(owner, repo),
       method: "DELETE",
+      authToken,
+    });
+  },
+
+  async archiveRepo(
+    owner: string,
+    repo: string,
+    authToken?: string
+  ): Promise<ApiClientResponse<UserRepoState>> {
+    if (!env.apiBaseUrl) {
+      return { ok: false, status: 0, error: "API base URL missing" };
+    }
+    return apiClient<UserRepoState>(env.apiBaseUrl, {
+      path: API_ROUTES.archive(owner, repo),
+      method: "POST",
+      authToken,
+    });
+  },
+
+  async unarchiveRepo(
+    owner: string,
+    repo: string,
+    authToken?: string
+  ): Promise<ApiClientResponse<UserRepoState>> {
+    if (!env.apiBaseUrl) {
+      return { ok: false, status: 0, error: "API base URL missing" };
+    }
+    return apiClient<UserRepoState>(env.apiBaseUrl, {
+      path: API_ROUTES.unarchive(owner, repo),
+      method: "POST",
+      authToken,
+    });
+  },
+
+  async listArchivedRepos(
+    authToken?: string
+  ): Promise<ApiClientResponse<UserRepoState[]>> {
+    if (!env.apiBaseUrl) {
+      return { ok: false, status: 0, error: "API base URL missing" };
+    }
+    return apiClient<UserRepoState[]>(env.apiBaseUrl, {
+      path: API_ROUTES.archived,
+      cache: "no-store",
       authToken,
     });
   },


### PR DESCRIPTION
- Backend: Add archive/unarchive/list_archived methods to UserSyncedRepoStore
- Backend: Add archive/unarchive/list_archived methods to RoadmapService
- Backend: Add API endpoints for archive/unarchive/list_archived
- Frontend: Add archive/unarchive/listArchived methods to repoService
- Frontend: Update RoadmapCatalogProvider with archived repos state and actions
- Frontend: Add Archived Repositories section to Settings dialog
- Sidebar already filters archived repos (no changes needed)
- All endpoints require authentication
- Archived repos are read-only in UI